### PR TITLE
Fix configurations not being visible in BrowserView

### DIFF
--- a/iOSiConnectivityiConfig/Source/General/ViewControllers/ICFileBrowserViewController.m
+++ b/iOSiConnectivityiConfig/Source/General/ViewControllers/ICFileBrowserViewController.m
@@ -63,11 +63,11 @@ using namespace GeneSysLib;
 
     switch (pid) {
       case DevicePID::iConnect2Plus:
-        supportedExtension = @"\\.IC2$";
+        supportedExtension = @"\\.icm2$";
         break;
 
       case DevicePID::iConnect4Plus:
-        supportedExtension = @"\\.IC4$";
+        supportedExtension = @"\\.icm4$";
         break;
     }
   }

--- a/iOSiConnectivityiConfig/Source/General/ViewControllers/ICViewController.m
+++ b/iOSiConnectivityiConfig/Source/General/ViewControllers/ICViewController.m
@@ -1349,7 +1349,11 @@ using namespace GeneSysLib;
   auto const &data = self.device->serialize();
   NSData *const nsData = [NSData dataWithBytes:data.data() length:data.size()];
 
-  [nsData writeToFile:[self fileNameWithExtension:fileName] atomically:YES];
+  BOOL writeSuccessful = [nsData writeToFile:[self fileNameWithExtension:fileName] atomically:YES];
+  if (writeSuccessful == NO)
+  {
+    NSLog(@"Could not write %s", [fileName cStringUsingEncoding:(NSASCIIStringEncoding)]);
+  }
   [self hideOverlay];
 }
 


### PR DESCRIPTION
This PR fixes that Configurations could not be loaded anymore (they were saved but were not visible in the Browser View).