### PR TITLE
Fix USB host reservation and MidiPortDetail access

### DIFF
--- a/GeneSysLib/MIDI/MIDIPortDetail.cpp
+++ b/GeneSysLib/MIDI/MIDIPortDetail.cpp
@@ -38,7 +38,9 @@ CmdEnum MIDIPortDetail::setCommand() { return Command::SetMIDIPortDetail; }
 MIDIPortDetail::MIDIPortDetail(void) : portID(), portType(), m_portDetails() {}
 
 const commandDataKey_t MIDIPortDetail::key() const {
-  return generateKey(Command::RetMIDIPortDetail, portID());
+  auto portId = portID();
+  auto key = generateKey(Command::RetMIDIPortDetail, portId);
+  return key;
 }
 
 Bytes MIDIPortDetail::generate() const {
@@ -64,6 +66,7 @@ void MIDIPortDetail::parse(BytesIter &beginIter, BytesIter &endIter) {
 
   if (version == versionNumber()) {
     portID = roWord(nextMidiWord(beginIter, endIter));
+    NSLog(@"Port Detail for port %i", portID);
     portType = roPortTypeEnum(
         static_cast<PortTypeEnum>(nextMidiByte(beginIter, endIter)));
 

--- a/GeneSysLib/MIDI/MIDIPortDetail.cpp
+++ b/GeneSysLib/MIDI/MIDIPortDetail.cpp
@@ -66,7 +66,6 @@ void MIDIPortDetail::parse(BytesIter &beginIter, BytesIter &endIter) {
 
   if (version == versionNumber()) {
     portID = roWord(nextMidiWord(beginIter, endIter));
-    NSLog(@"Port Detail for port %i", portID);
     portType = roPortTypeEnum(
         static_cast<PortTypeEnum>(nextMidiByte(beginIter, endIter)));
 

--- a/iOSiConnectivityiConfig/Source/Device/DeviceInfo.cpp
+++ b/iOSiConnectivityiConfig/Source/Device/DeviceInfo.cpp
@@ -391,7 +391,7 @@ bool DeviceInfo::sendNextSysex()
     mSysexMessages.pop();
 
     ++mUnansweredMessageCount;
-    NSLog(@"Unanswered %i", mUnansweredMessageCount);
+    //NSLog(@"Unanswered %i", mUnansweredMessageCount);
 
     // send the next sysex message
     comm->sendSysex(message);
@@ -515,7 +515,7 @@ void DeviceInfo::handleCommandData(CmdEnum _command, DeviceID _deviceID,
 
     sendNextSysex();
     --mUnansweredMessageCount;
-    NSLog(@"Unanswered %i", mUnansweredMessageCount);
+    //NSLog(@"Unanswered %i", mUnansweredMessageCount);
 
     bool isPendingSysexMessage = !mSysexMessages.empty();
     if (mUnansweredMessageCount == 0 && !isPendingSysexMessage)
@@ -549,7 +549,7 @@ void DeviceInfo::handleUSBHostMIDIDeviceDetailData(CmdEnum _command,
     sendNextSysex();
 
     --mUnansweredMessageCount;
-    NSLog(@"Unanswered %i", mUnansweredMessageCount);
+    //NSLog(@"Unanswered %i", mUnansweredMessageCount);
 
     bool isPendingSysexMessage = !mSysexMessages.empty();
     if (mUnansweredMessageCount == 0 && !isPendingSysexMessage)

--- a/iOSiConnectivityiConfig/Source/Device/DeviceInfo.cpp
+++ b/iOSiConnectivityiConfig/Source/Device/DeviceInfo.cpp
@@ -215,6 +215,65 @@ size_t DeviceInfo::audioPortInfoCount() const {
   return typeCount<AudioPortInfo>();
 }
 
+void DeviceInfo::notifyScreen()
+{
+  NSLog(@"Notify screen");
+  // check to see that a valid screen us waiting for a response
+  if (queryScreen != Screen::UnknownScreen)
+  {
+    // Remove doubles form list of queried items
+    {
+      // create a temporary set of commands
+      set<CmdEnum> tempSet;
+
+      // copy all quried items to that set
+      tempSet.insert(queriedItems.begin(), queriedItems.end());
+
+      // clear the list of quried items
+      queriedItems.clear();
+
+      // add items for the temp set to the quried items
+      queriedItems.insert(queriedItems.begin(), tempSet.begin(),
+                          tempSet.end());
+    }
+
+    // create an objective C object to store the results of the query
+    NSDictionary* result;
+    // create an Objective C object to store the list of queried items
+    {
+      NSMutableArray* const nsQuery = [NSMutableArray array];
+
+      // loop through all queried items
+      for (auto iter = queriedItems.begin(); iter != queriedItems.end(); ++iter)
+      {
+        // add an Object C object containing the queried object to the
+        // ObjC list of queried objects
+        [nsQuery addObject:[NSNumber numberWithInt:*iter]];
+      }
+
+      // create a dictionary of results
+      result = @{
+        // add the calling screen to the result
+        @"screen" : @((int)queryScreen),
+
+        // add the results to the results
+        @"query" : nsQuery
+      };
+    }
+
+    // post the query complete notification on the main thread
+    runOnMain(^{
+        [[NSNotificationCenter defaultCenter]
+            postNotificationName:@"queryCompleted"
+                          object:nil
+                        userInfo:result];});
+
+    // set the screen to the unknown screen (this prevents duplicate
+    // calls to query completed)
+    queryScreen = Screen::UnknownScreen;
+  }
+}
+
 void DeviceInfo::checkUnanswered()
 {
   NSLog(@"Check Unanswered %i", mUnansweredMessageCount);
@@ -323,7 +382,7 @@ bool DeviceInfo::sendNextSysex()
 {
   // is the sysex message queue empty?
   bool isPendingSysexMessage = !(mSysexMessages.empty());
-
+  
   if (isPendingSysexMessage)
   {
     // get the next pending sysex message
@@ -400,76 +459,6 @@ bool DeviceInfo::sendNextSysex()
     // if there are not pending sysex messages
     if (!isPendingSysexMessage)
     {
-      // check to make sure that the current query is complete
-      if (!currentQuery.empty())
-      {
-        // the current query isn't complete. There is an error
-        /*
-        NSLog(@"Current query isn't complete"
-               "but there are no pending messages.");
-        fprintf(stderr, "QUERY - [ ");
-        for (const auto& cmd : currentQuery) fprintf(stderr, "%04X ", cmd);
-        fprintf(stderr, "]\n");
-         */
-
-        timeout();
-      }
-
-      // check to see that a valid screen us waiting for a response
-      if (queryScreen != Screen::UnknownScreen)
-      {
-        // Remove doubles form list of queried items
-        {
-          // create a temporary set of commands
-          set<CmdEnum> tempSet;
-
-          // copy all quried items to that set
-          tempSet.insert(queriedItems.begin(), queriedItems.end());
-
-          // clear the list of quried items
-          queriedItems.clear();
-
-          // add items for the temp set to the quried items
-          queriedItems.insert(queriedItems.begin(), tempSet.begin(),
-                              tempSet.end());
-        }
-
-        // create an objective C object to store the results of the query
-        NSDictionary* result;
-        // create an Objective C object to store the list of queried items
-        {
-          NSMutableArray* const nsQuery = [NSMutableArray array];
-
-          // loop through all queried items
-          for (auto iter = queriedItems.begin(); iter != queriedItems.end(); ++iter)
-          {
-            // add an Object C object containing the queried object to the
-            // ObjC list of queried objects
-            [nsQuery addObject:[NSNumber numberWithInt:*iter]];
-          }
-
-          // create a dictionary of results
-          result = @{
-            // add the calling screen to the result
-            @"screen" : @((int)queryScreen),
-
-            // add the results to the results
-            @"query" : nsQuery
-          };
-        }
-
-        // post the query complete notification on the main thread
-        runOnMain(^{
-            [[NSNotificationCenter defaultCenter]
-                postNotificationName:@"queryCompleted"
-                              object:nil
-                            userInfo:result];});
-
-        // set the screen to the unknown screen (this prevents duplicate
-        // calls to query completed)
-        queryScreen = Screen::UnknownScreen;
-      }
-
       // if there are pending queries then deal with them now
       if (!pendingQueries.empty())
       {
@@ -520,12 +509,19 @@ void DeviceInfo::handleCommandData(CmdEnum _command, DeviceID _deviceID,
 {
   if (commonHandleCode(_deviceID, _transID))
   {
-    storedCommandData[_commandData.key()] = _commandData;
+    auto key = _commandData.key();
+    storedCommandData[key] = _commandData;
     queriedItems.push_back(_command);
 
     sendNextSysex();
     --mUnansweredMessageCount;
     NSLog(@"Unanswered %i", mUnansweredMessageCount);
+
+    bool isPendingSysexMessage = !mSysexMessages.empty();
+    if (mUnansweredMessageCount == 0 && !isPendingSysexMessage)
+    {
+      notifyScreen();
+    }
   }
 }
 
@@ -551,6 +547,15 @@ void DeviceInfo::handleUSBHostMIDIDeviceDetailData(CmdEnum _command,
     }
 
     sendNextSysex();
+
+    --mUnansweredMessageCount;
+    NSLog(@"Unanswered %i", mUnansweredMessageCount);
+
+    bool isPendingSysexMessage = !mSysexMessages.empty();
+    if (mUnansweredMessageCount == 0 && !isPendingSysexMessage)
+    {
+      notifyScreen();
+    }
   }
 }
 

--- a/iOSiConnectivityiConfig/Source/Device/DeviceInfo.h
+++ b/iOSiConnectivityiConfig/Source/Device/DeviceInfo.h
@@ -48,8 +48,6 @@ struct DeviceInfo
   typedef std::map<commandDataKey_t, commandData_t> CommandDataMap;
   typedef CommandDataMap::iterator CommandDataIterator;
 
-  inline void send(const Bytes &sysex) { comm->sendSysex(sysex); }
-
   template <typename DATA_T, typename... Ts> void send(Ts... vs) {
     DATA_T(deviceID, transID, vs...).send(comm);
   }
@@ -73,9 +71,10 @@ struct DeviceInfo
   // generated with the command and the variadic list of parameters
   template <typename T, typename... Ts>
   bool contains(Ts... ts) const {
+    auto key = GeneSysLib::generateKey<Ts...>(T::retCommand(), ts...);
     return MyAlgorithms::contains(
         storedCommandData,
-        GeneSysLib::generateKey<Ts...>(T::retCommand(), ts...));
+        key);
   }
 
   template <typename T>
@@ -192,6 +191,7 @@ struct DeviceInfo
 
  private:
   void checkUnanswered();
+  void notifyScreen();
   void registerAllHandlers();
   void unRegisterHandlerAllHandlers();
 

--- a/iOSiConnectivityiConfig/Source/MIDI/MIDIInfo/Delegates/ICReservedPortChoiceDelegate.m
+++ b/iOSiConnectivityiConfig/Source/MIDI/MIDIInfo/Delegates/ICReservedPortChoiceDelegate.m
@@ -48,7 +48,7 @@
   for (const auto& option : self.device->usbHostMIDIDeviceDetails) {
     if ((option.numMIDIIn() > 0) || (option.numMIDIOut() > 0)) {
 
-      const auto& maxPortID = MAX(option.numMIDIIn(), option.numMIDIOut());
+      const auto maxPortID = MAX(option.numMIDIIn(), option.numMIDIOut());
       for (Word portID = 1; portID <= maxPortID; ++portID) {
         NSString* portName = [NSString
             stringWithFormat:@"%s %s (Port %d)", option.vendorName().c_str(),
@@ -84,11 +84,11 @@
   MIDIPortDetail portDetail = self.device->get<MIDIPortDetail>(self.portID);
   MIDIPortDetailTypes::USBHost usbHost = portDetail.getUSBHost();
 
-  if (!usbHost.isReserved()) {
-    return 0;
-  }
-
   NSInteger value = 0;
+
+    if (usbHost.isReserved()) {
+      ++value;
+    }
 
   for (const auto& option : self.device->usbHostMIDIDeviceDetails) {
     if ((option.hostedUSBVendorID() == usbHost.hostedUSBVendorID()) &&

--- a/iOSiConnectivityiConfig/Source/MIDI/MIDIInfo/ViewControllers/ICMIDIInfoViewController.m
+++ b/iOSiConnectivityiConfig/Source/MIDI/MIDIInfo/ViewControllers/ICMIDIInfoViewController.m
@@ -60,7 +60,7 @@ using namespace std;
 
     assert(device);
 
-    const auto& isiPhone = ([[UIDevice currentDevice] userInterfaceIdiom] ==
+    const auto isiPhone = ([[UIDevice currentDevice] userInterfaceIdiom] ==
                             UIUserInterfaceIdiomPhone);
 
     if (midiInfo.versionNumber() == 0x01) {
@@ -158,11 +158,11 @@ using namespace std;
       [tempSectionArray addObject:midiInfoArray];
 
       int numPorts = device->typeCount<MIDIPortInfo>();
-      for (int portID = 1; portID <= numPorts; ++portID) {
+      for (Word portID = 1; portID <= numPorts; ++portID) {
         // title
         {
           MIDIPortInfo& port = device->get<MIDIPortInfo>(portID);
-          const auto& portInfo = port.portInfo();
+          const auto portInfo = port.portInfo();
           NSMutableString* title = [NSMutableString
               stringWithFormat:@"Port Information %d\n", portID];
 


### PR DESCRIPTION
This version fixes the moment when the screen is notified about finished data retrieval which was not yet correct.
MidiPortDetail were not found because of a mismatched data type (int instead of Word). 
USB Host reservation was not yet completely correct. This should be better now.